### PR TITLE
Fix dead URL in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=Raphael Pisoni
 sentence=Library for the <a href="https://www.play.goolge.com">ESP Notify App</a>.
 paragraph=Allows you to send Notifications to your phone easily.
 category=Device Control
-url=https://www.play.google.com
+url=https://play.google.com/store/apps/details?id=com.espnotify.rpi.android.espnotify
 architectures=esp8266


### PR DESCRIPTION
The www on the previous URL caused it to not load. I have fixed the URL and pointed it directly to the App.